### PR TITLE
Verion bump to latest eigen master.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,10 @@ from glob import glob
 
 class EigenConan(ConanFile):
     name = "eigen"
-    version = "3.3.7.1"
+    upstream_version = "3.3.7"
+    package_revision = "-r1"
+    version = "{0}{1}".format(upstream_version, package_revision)
+
     url = "https://github.com/ulricheck/conan-eigen"
     homepage = "http://eigen.tuxfamily.org"
     description = "Eigen is a C++ template library for linear algebra: matrices, vectors, \

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,37 +8,25 @@ from glob import glob
 
 class EigenConan(ConanFile):
     name = "eigen"
-    version = "3.3.7"
+    version = "3.3.7.1"
     url = "https://github.com/ulricheck/conan-eigen"
     homepage = "http://eigen.tuxfamily.org"
     description = "Eigen is a C++ template library for linear algebra: matrices, vectors, \
                    numerical solvers, and related algorithms."
     license = "Mozilla Public License Version 2.0"
-    no_copy_source = False
-    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
     options = {"EIGEN_USE_BLAS": [True, False],
                "EIGEN_USE_LAPACKE": [True, False],
                "EIGEN_USE_LAPACKE_STRICT": [True, False]}
     default_options = "EIGEN_USE_BLAS=False", "EIGEN_USE_LAPACKE=False", "EIGEN_USE_LAPACKE_STRICT=False"
 
-    source_subfolder = "source_subfolder"
-
-    exports = [
-            "patches/Half.h.patch",
-        ]
-
-
     def source(self):
-        tools.get("https://bitbucket.org/eigen/eigen/get/{0}.tar.gz".format(self.version))
-        os.rename(glob("eigen-eigen-*")[0], self.source_subfolder)
+        git = tools.Git(folder="source_subfolder")
+        git.clone("https://gitlab.com/libeigen/eigen.git","master")
+        self.run("cd source_subfolder && git checkout 46f8a18567731925e06a7389a6c611e1dc420ea8")
 
 
     def build(self):
-        eigen_source_dir = os.path.join(
-
-            self.source_folder, self.source_subfolder)
-        tools.patch(eigen_source_dir, "patches/Half.h.patch", strip=1)
-
         #Import common flags and defines
         cmake = CMake(self)
        


### PR DESCRIPTION
Fixes pcpd_cuda comipilation issues with VS2017+nvcc device code: 
e.g. JacobiSVD/BCDSVD not compiling because of some macros: [https://stackoverflow.com/questions/48341389/error-while-compiling-eigen-library-v3-3-4-with-vs2017-nvcc-cuda-9-0](https://stackoverflow.com/questions/48341389/error-while-compiling-eigen-library-v3-3-4-with-vs2017-nvcc-cuda-9-0). Also hadd seems to be ambigious some times: https://gitlab.com/libeigen/eigen/-/issues/1526. These issues are already fixed in Eigen-master, but Eigen has not had a new release since over a 1 year. Calling it 3.3.7-r1 internally to not clash with future versions. This is pinned to a recent commit in the Eigen 3.3-branch so it will be reproducable.
Please don't merge with 3.3.7, but create a new branch 3.3.7-r1