### PR TITLE
Half.h patch is still needed in 3.3.9 for windows

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -24,7 +24,7 @@ class EigenConan(ConanFile):
     source_subfolder = "source_subfolder"
 
     exports = [
-            # "patches/Half.h.patch",
+            "patches/Half.h.patch",
         ]
 
 
@@ -35,7 +35,7 @@ class EigenConan(ConanFile):
 
     def build(self):
         eigen_source_dir = os.path.join(self.source_folder, self.source_subfolder)
-        # tools.patch(eigen_source_dir, "patches/Half.h.patch", strip=1)
+        tools.patch(eigen_source_dir, "patches/Half.h.patch", strip=1)
 
         #Import common flags and defines
         cmake = CMake(self)

--- a/patches/Half.h.patch
+++ b/patches/Half.h.patch
@@ -2,7 +2,7 @@ diff --git a/Eigen/src/Core/arch/CUDA/Half.h b/Eigen/src/Core/arch/CUDA/Half.h
 index 755e6209d..42a3582a2 100644
 --- a/Eigen/src/Core/arch/CUDA/Half.h
 +++ b/Eigen/src/Core/arch/CUDA/Half.h
-@@ -209,7 +209,11 @@ namespace half_impl {
+@@ -210,7 +210,11 @@ namespace half_impl {
  // conversion steps back and forth.
  
  EIGEN_STRONG_INLINE __device__ half operator + (const half& a, const half& b) {


### PR DESCRIPTION
ambigious overload between __hadd(int,int) and __hadd(_half, _half) somehow this is fixed in eigen-master for ages but not in the latest release branch.