### PR TITLE
Patch for more Functionality in Eigen-device code

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,9 @@ from glob import glob
 
 class EigenConan(ConanFile):
     name = "eigen"
-    version = "3.3.9"
+    upstream_version = "3.3.9"
+    package_revision = "-r1"
+    version = "{0}{1}".format(upstream_version, package_revision)
     url = "https://github.com/ulricheck/conan-eigen"
     homepage = "http://eigen.tuxfamily.org"
     description = "Eigen is a C++ template library for linear algebra: matrices, vectors, \
@@ -25,17 +27,19 @@ class EigenConan(ConanFile):
 
     exports = [
             "patches/Half.h.patch",
+            "patches/ProductEvaluators.h.patch",
         ]
 
 
     def source(self):
-        tools.get("https://gitlab.com/libeigen/eigen/-/archive/{0}/eigen-{0}.tar.gz".format(self.version))
-        os.rename(glob("eigen-{0}*".format(self.version))[0], self.source_subfolder)
+        tools.get("https://gitlab.com/libeigen/eigen/-/archive/{0}/eigen-{0}.tar.gz".format(self.upstream_version))
+        os.rename(glob("eigen-{0}*".format(self.upstream_version))[0], self.source_subfolder)
 
 
     def build(self):
         eigen_source_dir = os.path.join(self.source_folder, self.source_subfolder)
         tools.patch(eigen_source_dir, "patches/Half.h.patch", strip=1)
+        tools.patch(eigen_source_dir, "patches/ProductEvaluators.h.patch", strip=1)
 
         #Import common flags and defines
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,6 +28,9 @@ class EigenConan(ConanFile):
     exports = [
             "patches/Half.h.patch",
             "patches/ProductEvaluators.h.patch",
+            "patches/MatrixBase.h.patch",
+            "patches/Macros.h.patch",
+            "patches/GenericPacketMath.h.patch"
         ]
 
 
@@ -40,6 +43,9 @@ class EigenConan(ConanFile):
         eigen_source_dir = os.path.join(self.source_folder, self.source_subfolder)
         tools.patch(eigen_source_dir, "patches/Half.h.patch", strip=1)
         tools.patch(eigen_source_dir, "patches/ProductEvaluators.h.patch", strip=1)
+        tools.patch(eigen_source_dir, "patches/MatrixBase.h.patch", strip=1)
+        tools.patch(eigen_source_dir, "patches/Macros.h.patch", strip=1)
+        tools.patch(eigen_source_dir, "patches/GenericPacketMath.h.patch", strip=1)
 
         #Import common flags and defines
         cmake = CMake(self)

--- a/patches/GenericPacketMath.h.patch
+++ b/patches/GenericPacketMath.h.patch
@@ -1,0 +1,13 @@
+diff --git a/Eigen/src/Core/GenericPacketMath.h b/Eigen/src/Core/GenericPacketMath.h
+index 755e6209d..42a3582a2 100644
+--- a/Eigen/src/Core/GenericPacketMath.h
++++ b/Eigen/src/Core/GenericPacketMath.h
+@@ -299,7 +299,7 @@ template<typename Scalar, typename Packet> EIGEN_DEVICE_FUNC inline void pstoreu
+ template<typename Scalar> EIGEN_DEVICE_FUNC inline void prefetch(const Scalar* addr)
+ {
+ #ifdef __CUDA_ARCH__
+-#if defined(__LP64__)
++#if defined(__LP64__) || defined(_WIN64)
+   // 64-bit pointer operand constraint for inlined asm
+   asm(" prefetch.L1 [ %1 ];" : "=l"(addr) : "l"(addr));
+ #else

--- a/patches/Macros.h.patch
+++ b/patches/Macros.h.patch
@@ -1,0 +1,13 @@
+diff --git a/Eigen/src/Core/util/Macros.h b/Eigen/src/Core/util/Macros.h
+index 755e6209d..42a3582a2 100644
+--- a/Eigen/src/Core/util/Macros.h
++++ b/Eigen/src/Core/util/Macros.h
+@@ -829,7 +829,7 @@ namespace Eigen {
+ // just an empty macro !
+ #define EIGEN_EMPTY
+ 
+-#if EIGEN_COMP_MSVC_STRICT && (EIGEN_COMP_MSVC < 1900 || EIGEN_CUDACC_VER>0)
++#if EIGEN_COMP_MSVC_STRICT && (EIGEN_COMP_MSVC < 1900 || (EIGEN_CUDACC_VER != 0 && EIGEN_CUDACC_VER<11000))
+   // for older MSVC versions, as well as 1900 && CUDA 8, using the base operator is sufficient (cf Bugs 1000, 1324)
+   #define EIGEN_INHERIT_ASSIGNMENT_EQUAL_OPERATOR(Derived) \
+     using Base::operator =;

--- a/patches/MatrixBase.h.patch
+++ b/patches/MatrixBase.h.patch
@@ -1,0 +1,16 @@
+diff --git a/Eigen/src/Core/MatrixBase.h b/Eigen/src/Core/MatrixBase.h
+index 755e6209d..42a3582a2 100644
+--- a/Eigen/src/Core/MatrixBase.h
++++ b/Eigen/src/Core/MatrixBase.h
+@@ -174,9 +174,11 @@ template<typename Derived> class MatrixBase
+     Derived& operator*=(const EigenBase<OtherDerived>& other);
+ 
+     template<typename OtherDerived>
++    EIGEN_DEVICE_FUNC
+     void applyOnTheLeft(const EigenBase<OtherDerived>& other);
+ 
+     template<typename OtherDerived>
++    EIGEN_DEVICE_FUNC
+     void applyOnTheRight(const EigenBase<OtherDerived>& other);
+ 
+     template<typename DiagonalDerived>

--- a/patches/ProductEvaluators.h.patch
+++ b/patches/ProductEvaluators.h.patch
@@ -1,0 +1,259 @@
+diff --git a/Eigen/src/Core/ProductEvaluators.h b/Eigen/src/Core/ProductEvaluators.h
+index 755e6209d..42a3582a2 100644
+--- a/Eigen/src/Core/ProductEvaluators.h
++++ b/Eigen/src/Core/ProductEvaluators.h
+@@ -137,7 +137,7 @@ struct Assignment<DstXprType, Product<Lhs,Rhs,Options>, internal::assign_op<Scal
+   typename enable_if<(Options==DefaultProduct || Options==AliasFreeProduct)>::type>
+ {
+   typedef Product<Lhs,Rhs,Options> SrcXprType;
+-  static EIGEN_STRONG_INLINE
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+   void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<Scalar,Scalar> &)
+   {
+     Index dstRows = src.rows();
+@@ -155,7 +155,7 @@ struct Assignment<DstXprType, Product<Lhs,Rhs,Options>, internal::add_assign_op<
+   typename enable_if<(Options==DefaultProduct || Options==AliasFreeProduct)>::type>
+ {
+   typedef Product<Lhs,Rhs,Options> SrcXprType;
+-  static EIGEN_STRONG_INLINE
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+   void run(DstXprType &dst, const SrcXprType &src, const internal::add_assign_op<Scalar,Scalar> &)
+   {
+     eigen_assert(dst.rows() == src.rows() && dst.cols() == src.cols());
+@@ -170,7 +170,7 @@ struct Assignment<DstXprType, Product<Lhs,Rhs,Options>, internal::sub_assign_op<
+   typename enable_if<(Options==DefaultProduct || Options==AliasFreeProduct)>::type>
+ {
+   typedef Product<Lhs,Rhs,Options> SrcXprType;
+-  static EIGEN_STRONG_INLINE
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+   void run(DstXprType &dst, const SrcXprType &src, const internal::sub_assign_op<Scalar,Scalar> &)
+   {
+     eigen_assert(dst.rows() == src.rows() && dst.cols() == src.cols());
+@@ -190,7 +190,7 @@ struct Assignment<DstXprType, CwiseBinaryOp<internal::scalar_product_op<ScalarBi
+   typedef CwiseBinaryOp<internal::scalar_product_op<ScalarBis,Scalar>,
+                         const CwiseNullaryOp<internal::scalar_constant_op<ScalarBis>,Plain>,
+                         const Product<Lhs,Rhs,DefaultProduct> > SrcXprType;
+-  static EIGEN_STRONG_INLINE
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+   void run(DstXprType &dst, const SrcXprType &src, const AssignFunc& func)
+   {
+     call_assignment_no_alias(dst, (src.lhs().functor().m_other * src.rhs().lhs())*src.rhs().rhs(), func);
+@@ -217,7 +217,7 @@ template<typename DstXprType, typename OtherXpr, typename ProductType, typename
+ struct assignment_from_xpr_op_product
+ {
+   template<typename SrcXprType, typename InitialFunc>
+-  static EIGEN_STRONG_INLINE
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+   void run(DstXprType &dst, const SrcXprType &src, const InitialFunc& /*func*/)
+   {
+     call_assignment_no_alias(dst, src.lhs(), Func1());
+@@ -246,19 +246,19 @@ template<typename Lhs, typename Rhs>
+ struct generic_product_impl<Lhs,Rhs,DenseShape,DenseShape,InnerProduct>
+ {
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void evalTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void evalTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
+   {
+     dst.coeffRef(0,0) = (lhs.transpose().cwiseProduct(rhs)).sum();
+   }
+   
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void addTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void addTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
+   {
+     dst.coeffRef(0,0) += (lhs.transpose().cwiseProduct(rhs)).sum();
+   }
+   
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void subTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void subTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
+   { dst.coeffRef(0,0) -= (lhs.transpose().cwiseProduct(rhs)).sum(); }
+ };
+ 
+@@ -312,25 +312,25 @@ struct generic_product_impl<Lhs,Rhs,DenseShape,DenseShape,OuterProduct>
+   };
+   
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void evalTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void evalTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
+   {
+     internal::outer_product_selector_run(dst, lhs, rhs, set(), is_row_major<Dst>());
+   }
+   
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void addTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void addTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
+   {
+     internal::outer_product_selector_run(dst, lhs, rhs, add(), is_row_major<Dst>());
+   }
+   
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void subTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void subTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
+   {
+     internal::outer_product_selector_run(dst, lhs, rhs, sub(), is_row_major<Dst>());
+   }
+   
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void scaleAndAddTo(Dst& dst, const Lhs& lhs, const Rhs& rhs, const Scalar& alpha)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void scaleAndAddTo(Dst& dst, const Lhs& lhs, const Rhs& rhs, const Scalar& alpha)
+   {
+     internal::outer_product_selector_run(dst, lhs, rhs, adds(alpha), is_row_major<Dst>());
+   }
+@@ -345,19 +345,19 @@ struct generic_product_impl_base
+   typedef typename Product<Lhs,Rhs>::Scalar Scalar;
+   
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void evalTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void evalTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
+   { dst.setZero(); scaleAndAddTo(dst, lhs, rhs, Scalar(1)); }
+ 
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void addTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void addTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
+   { scaleAndAddTo(dst,lhs, rhs, Scalar(1)); }
+ 
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void subTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void subTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
+   { scaleAndAddTo(dst, lhs, rhs, Scalar(-1)); }
+   
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void scaleAndAddTo(Dst& dst, const Lhs& lhs, const Rhs& rhs, const Scalar& alpha)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void scaleAndAddTo(Dst& dst, const Lhs& lhs, const Rhs& rhs, const Scalar& alpha)
+   { Derived::scaleAndAddTo(dst,lhs,rhs,alpha); }
+ 
+ };
+@@ -373,7 +373,7 @@ struct generic_product_impl<Lhs,Rhs,DenseShape,DenseShape,GemvProduct>
+   typedef typename internal::remove_all<typename internal::conditional<int(Side)==OnTheRight,LhsNested,RhsNested>::type>::type MatrixType;
+ 
+   template<typename Dest>
+-  static EIGEN_STRONG_INLINE void scaleAndAddTo(Dest& dst, const Lhs& lhs, const Rhs& rhs, const Scalar& alpha)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void scaleAndAddTo(Dest& dst, const Lhs& lhs, const Rhs& rhs, const Scalar& alpha)
+   {
+     LhsNested actual_lhs(lhs);
+     RhsNested actual_rhs(rhs);
+@@ -390,7 +390,7 @@ struct generic_product_impl<Lhs,Rhs,DenseShape,DenseShape,CoeffBasedProductMode>
+   typedef typename Product<Lhs,Rhs>::Scalar Scalar;
+   
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void evalTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void evalTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
+   {
+     // Same as: dst.noalias() = lhs.lazyProduct(rhs);
+     // but easier on the compiler side
+@@ -398,14 +398,14 @@ struct generic_product_impl<Lhs,Rhs,DenseShape,DenseShape,CoeffBasedProductMode>
+   }
+ 
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void addTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void addTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
+   {
+     // dst.noalias() += lhs.lazyProduct(rhs);
+     call_assignment_no_alias(dst, lhs.lazyProduct(rhs), internal::add_assign_op<typename Dst::Scalar,Scalar>());
+   }
+   
+   template<typename Dst>
+-  static EIGEN_STRONG_INLINE void subTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void subTo(Dst& dst, const Lhs& lhs, const Rhs& rhs)
+   {
+     // dst.noalias() -= lhs.lazyProduct(rhs);
+     call_assignment_no_alias(dst, lhs.lazyProduct(rhs), internal::sub_assign_op<typename Dst::Scalar,Scalar>());
+@@ -641,7 +641,7 @@ struct product_evaluator<Product<Lhs, Rhs, DefaultProduct>, LazyCoeffBasedProduc
+ template<int UnrollingIndex, typename Lhs, typename Rhs, typename Packet, int LoadMode>
+ struct etor_product_packet_impl<RowMajor, UnrollingIndex, Lhs, Rhs, Packet, LoadMode>
+ {
+-  static EIGEN_STRONG_INLINE void run(Index row, Index col, const Lhs& lhs, const Rhs& rhs, Index innerDim, Packet &res)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void run(Index row, Index col, const Lhs& lhs, const Rhs& rhs, Index innerDim, Packet &res)
+   {
+     etor_product_packet_impl<RowMajor, UnrollingIndex-1, Lhs, Rhs, Packet, LoadMode>::run(row, col, lhs, rhs, innerDim, res);
+     res =  pmadd(pset1<Packet>(lhs.coeff(row, Index(UnrollingIndex-1))), rhs.template packet<LoadMode,Packet>(Index(UnrollingIndex-1), col), res);
+@@ -651,7 +651,7 @@ struct etor_product_packet_impl<RowMajor, UnrollingIndex, Lhs, Rhs, Packet, Load
+ template<int UnrollingIndex, typename Lhs, typename Rhs, typename Packet, int LoadMode>
+ struct etor_product_packet_impl<ColMajor, UnrollingIndex, Lhs, Rhs, Packet, LoadMode>
+ {
+-  static EIGEN_STRONG_INLINE void run(Index row, Index col, const Lhs& lhs, const Rhs& rhs, Index innerDim, Packet &res)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void run(Index row, Index col, const Lhs& lhs, const Rhs& rhs, Index innerDim, Packet &res)
+   {
+     etor_product_packet_impl<ColMajor, UnrollingIndex-1, Lhs, Rhs, Packet, LoadMode>::run(row, col, lhs, rhs, innerDim, res);
+     res =  pmadd(lhs.template packet<LoadMode,Packet>(row, Index(UnrollingIndex-1)), pset1<Packet>(rhs.coeff(Index(UnrollingIndex-1), col)), res);
+@@ -661,7 +661,7 @@ struct etor_product_packet_impl<ColMajor, UnrollingIndex, Lhs, Rhs, Packet, Load
+ template<typename Lhs, typename Rhs, typename Packet, int LoadMode>
+ struct etor_product_packet_impl<RowMajor, 1, Lhs, Rhs, Packet, LoadMode>
+ {
+-  static EIGEN_STRONG_INLINE void run(Index row, Index col, const Lhs& lhs, const Rhs& rhs, Index /*innerDim*/, Packet &res)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void run(Index row, Index col, const Lhs& lhs, const Rhs& rhs, Index /*innerDim*/, Packet &res)
+   {
+     res = pmul(pset1<Packet>(lhs.coeff(row, Index(0))),rhs.template packet<LoadMode,Packet>(Index(0), col));
+   }
+@@ -670,7 +670,7 @@ struct etor_product_packet_impl<RowMajor, 1, Lhs, Rhs, Packet, LoadMode>
+ template<typename Lhs, typename Rhs, typename Packet, int LoadMode>
+ struct etor_product_packet_impl<ColMajor, 1, Lhs, Rhs, Packet, LoadMode>
+ {
+-  static EIGEN_STRONG_INLINE void run(Index row, Index col, const Lhs& lhs, const Rhs& rhs, Index /*innerDim*/, Packet &res)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void run(Index row, Index col, const Lhs& lhs, const Rhs& rhs, Index /*innerDim*/, Packet &res)
+   {
+     res = pmul(lhs.template packet<LoadMode,Packet>(row, Index(0)), pset1<Packet>(rhs.coeff(Index(0), col)));
+   }
+@@ -679,7 +679,7 @@ struct etor_product_packet_impl<ColMajor, 1, Lhs, Rhs, Packet, LoadMode>
+ template<typename Lhs, typename Rhs, typename Packet, int LoadMode>
+ struct etor_product_packet_impl<RowMajor, 0, Lhs, Rhs, Packet, LoadMode>
+ {
+-  static EIGEN_STRONG_INLINE void run(Index /*row*/, Index /*col*/, const Lhs& /*lhs*/, const Rhs& /*rhs*/, Index /*innerDim*/, Packet &res)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void run(Index /*row*/, Index /*col*/, const Lhs& /*lhs*/, const Rhs& /*rhs*/, Index /*innerDim*/, Packet &res)
+   {
+     res = pset1<Packet>(typename unpacket_traits<Packet>::type(0));
+   }
+@@ -688,7 +688,7 @@ struct etor_product_packet_impl<RowMajor, 0, Lhs, Rhs, Packet, LoadMode>
+ template<typename Lhs, typename Rhs, typename Packet, int LoadMode>
+ struct etor_product_packet_impl<ColMajor, 0, Lhs, Rhs, Packet, LoadMode>
+ {
+-  static EIGEN_STRONG_INLINE void run(Index /*row*/, Index /*col*/, const Lhs& /*lhs*/, const Rhs& /*rhs*/, Index /*innerDim*/, Packet &res)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void run(Index /*row*/, Index /*col*/, const Lhs& /*lhs*/, const Rhs& /*rhs*/, Index /*innerDim*/, Packet &res)
+   {
+     res = pset1<Packet>(typename unpacket_traits<Packet>::type(0));
+   }
+@@ -697,7 +697,7 @@ struct etor_product_packet_impl<ColMajor, 0, Lhs, Rhs, Packet, LoadMode>
+ template<typename Lhs, typename Rhs, typename Packet, int LoadMode>
+ struct etor_product_packet_impl<RowMajor, Dynamic, Lhs, Rhs, Packet, LoadMode>
+ {
+-  static EIGEN_STRONG_INLINE void run(Index row, Index col, const Lhs& lhs, const Rhs& rhs, Index innerDim, Packet& res)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void run(Index row, Index col, const Lhs& lhs, const Rhs& rhs, Index innerDim, Packet& res)
+   {
+     res = pset1<Packet>(typename unpacket_traits<Packet>::type(0));
+     for(Index i = 0; i < innerDim; ++i)
+@@ -708,7 +708,7 @@ struct etor_product_packet_impl<RowMajor, Dynamic, Lhs, Rhs, Packet, LoadMode>
+ template<typename Lhs, typename Rhs, typename Packet, int LoadMode>
+ struct etor_product_packet_impl<ColMajor, Dynamic, Lhs, Rhs, Packet, LoadMode>
+ {
+-  static EIGEN_STRONG_INLINE void run(Index row, Index col, const Lhs& lhs, const Rhs& rhs, Index innerDim, Packet& res)
++  static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void run(Index row, Index col, const Lhs& lhs, const Rhs& rhs, Index innerDim, Packet& res)
+   {
+     res = pset1<Packet>(typename unpacket_traits<Packet>::type(0));
+     for(Index i = 0; i < innerDim; ++i)
+@@ -835,14 +835,14 @@ public:
+   
+ protected:
+   template<int LoadMode,typename PacketType>
+-  EIGEN_STRONG_INLINE PacketType packet_impl(Index row, Index col, Index id, internal::true_type) const
++  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE PacketType packet_impl(Index row, Index col, Index id, internal::true_type) const
+   {
+     return internal::pmul(m_matImpl.template packet<LoadMode,PacketType>(row, col),
+                           internal::pset1<PacketType>(m_diagImpl.coeff(id)));
+   }
+   
+   template<int LoadMode,typename PacketType>
+-  EIGEN_STRONG_INLINE PacketType packet_impl(Index row, Index col, Index id, internal::false_type) const
++  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE PacketType packet_impl(Index row, Index col, Index id, internal::false_type) const
+   {
+     enum {
+       InnerSize = (MatrixType::Flags & RowMajorBit) ? MatrixType::ColsAtCompileTime : MatrixType::RowsAtCompileTime,
+@@ -895,7 +895,7 @@ struct product_evaluator<Product<Lhs, Rhs, ProductKind>, ProductTag, DiagonalSha
+   }
+   
+   template<int LoadMode,typename PacketType>
+-  EIGEN_STRONG_INLINE PacketType packet(Index idx) const
++  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE PacketType packet(Index idx) const
+   {
+     return packet<LoadMode,PacketType>(int(StorageOrder)==ColMajor?idx:0,int(StorageOrder)==ColMajor?0:idx);
+   }


### PR DESCRIPTION
- allow simple matrix-solvers like LLT and PartialLU to be used inside cuda-device code, which requires some additional __host__ __device__ directives in key functions
- allow other useful functions to be used in cuda-device code- like small dense matrix-matrix products
- version bump to 3.3.9-r1
